### PR TITLE
remove courier from lint make target

### DIFF
--- a/make/lint.mk
+++ b/make/lint.mk
@@ -8,7 +8,7 @@ include ./make/go.mk
 
 .PHONY: lint
 ## Runs linters on Go code files and YAML files
-lint: lint-go-code lint-yaml courier
+lint: lint-go-code lint-yaml
 
 YAML_FILES := $(shell find . -path ./vendor -prune -o -type f -regex ".*y[a]ml" -print)
 .PHONY: lint-yaml


### PR DESCRIPTION
This PR removes `courier` from `lint` make target as not required at this point. We may add this in future to validate olm manifests.