### PR TITLE
fix: failed to initialize build cache during go build

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -3,6 +3,7 @@ LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Devtools <devtools@redhat.com>"
 ENV LANG=en_US.utf8
 ENV GOPATH /tmp/go
+ENV GOCACHE /tmp/.cache
 ARG GO_PACKAGE_PATH=github.com/fabric8-services/toolchain-operator
 
 ENV GIT_COMMITTER_NAME devtools


### PR DESCRIPTION
Fix build issue: https://prow.svc.ci.openshift.org/log?id=26&job=pull-ci-fabric8-services-toolchain-operator-master-build

Reference links:
https://github.com/golang/go/issues/26280#issuecomment-445294378